### PR TITLE
Add missing authors to article's author list

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -228,6 +228,23 @@ article#rebuttal {
             "authorURL": "https://schubert.io/",
             "affiliation": "OpenAI",
             "affiliationURL": "https://openai.com"
+          },
+          {
+            "author": "Chelsea Voss",
+            "authorURL": "https://csvoss.com/",
+            "affiliation": "OpenAI",
+            "affiliationURL": "https://openai.com"
+          },
+          {
+            "author": "Ben Egan",
+            "affiliation": "Mount Royal University",
+            "affiliationURL": "https://mtroyal.ca/"
+          },
+          {
+            "author": "Swee Kiat Lim",
+            "authorURL": "https://greentfrapp.github.io/",
+            "affiliation": "Stanford University",
+            "affiliationURL": "https://stanford.edu/"
           }
         ],
         "katex": {

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -51,6 +51,23 @@
             "authorURL": "https://schubert.io/",
             "affiliation": "OpenAI",
             "affiliationURL": "https://openai.com"
+          },
+          {
+            "author": "Chelsea Voss",
+            "authorURL": "https://csvoss.com/",
+            "affiliation": "OpenAI",
+            "affiliationURL": "https://openai.com"
+          },
+          {
+            "author": "Ben Egan",
+            "affiliation": "Mount Royal University",
+            "affiliationURL": "https://mtroyal.ca/"
+          },
+          {
+            "author": "Swee Kiat Lim",
+            "authorURL": "https://greentfrapp.github.io/",
+            "affiliation": "Stanford University",
+            "affiliationURL": "https://stanford.edu/"
           }
         ],
         "katex": {


### PR DESCRIPTION
https://distill.pub/2020/circuits/

Under the citation information section for the article, it says:

> If you wish to cite this thread as a whole, citation information can be found below. The author order is **all participants in the thread** in alphabetical order. **Since this is a living document, the citation may add additional authors as it evolves.**

Currently the Circuits thread is missing 3 of the authors who have participated in the thread. This PR adds those 3 missing authors.